### PR TITLE
Fix plugin_dir for debian Platform

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -36,10 +36,8 @@ when 'debian'
   default['nrpe']['conf_dir']          = '/etc/nagios'
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib/i386-linux-gnu'
-    default['nrpe']['plugin_dir']      = '/usr/lib/nagios/plugins'
   else
     default['nrpe']['ssl_lib_dir']     = '/usr/lib/x86_64-linux-gnu'
-    default['nrpe']['plugin_dir']      = '/usr/lib64/nagios/plugins'
   end
   if node['nrpe']['install_method'] == 'package'
     default['nrpe']['service_name']    = 'nagios-nrpe-server'


### PR DESCRIPTION
On Ubuntu 12.04 x86_64 the plugin dir is still /usr/lib/nagios/plugins.
On CentOS it seems to be /usr/lib64/nagios/plugins but not on Ubuntu.
