### PR TITLE
Fix plugin_dir for RHEL/Fedora systems

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -51,9 +51,11 @@ when 'rhel', 'fedora'
   if node['kernel']['machine'] == 'i686'
     default['nrpe']['home']            = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib'
+    default['nrpe']['plugin_dir']      = '/usr/lib/nagios/plugins'
   else
     default['nrpe']['home']            = '/usr/lib64/nagios'
     default['nrpe']['ssl_lib_dir']     = '/usr/lib64'
+    default['nrpe']['plugin_dir']      = '/usr/lib64/nagios/plugins'
   end
   default['nrpe']['service_name']      = 'nrpe'
   default['nrpe']['conf_dir']          = '/etc/nagios'


### PR DESCRIPTION
The plugin_dir attribute for RedHat-based systems was empty,
which meant that nrpe_check would end up creating bogus config
files.
