### PR TITLE
Added reload to the NRPE client service & modified the LWRP to call reload

### DIFF
--- a/providers/check.rb
+++ b/providers/check.rb
@@ -33,7 +33,7 @@ action :add do
     group node['nrpe']['group']
     mode '0640'
     content file_contents
-    notifies :restart, "service[#{node['nrpe']['service_name']}]"
+    notifies :reload, "service[#{node['nrpe']['service_name']}]"
   end
   new_resource.updated_by_last_action(f.updated_by_last_action?)
 end
@@ -43,7 +43,7 @@ action :remove do
     Chef::Log.info "Removing #{new_resource.command_name} from #{node['nrpe']['conf_dir']}/nrpe.d/"
     f = file "#{node['nrpe']['conf_dir']}/nrpe.d/#{new_resource.command_name}.cfg" do
       action :delete
-      notifies :restart, "service[#{node['nrpe']['service_name']}]"
+      notifies :reload, "service[#{node['nrpe']['service_name']}]"
     end
     new_resource.updated_by_last_action(f.updated_by_last_action?)
   end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -72,5 +72,5 @@ end
 
 service node['nrpe']['service_name'] do
   action [:start, :enable]
-  supports :restart => true, :status => false
+  supports :restart => true, :reload => true, :status => true
 end


### PR DESCRIPTION
Added reload to the NRPE client service & modified the LWRP to call this rather than restart. This stops unneeded crits being generated as a result of adding or removing a check via the LWRP - reloading NRPE is graceful, restarting is not.

(initially opened as https://github.com/tas50/nagios/pull/265 before realising this had been split out.)
