### PR TITLE
when using lab functions they should be sourced

### DIFF
--- a/templates/default/nagios-nrpe-server.erb
+++ b/templates/default/nagios-nrpe-server.erb
@@ -25,6 +25,9 @@ fi
 # Check that networking is up.
 [ ${NETWORKING} = "no" ] && exit 0
 
+<% else -%>
+. /lib/lsb/init-functions
+
 <% end -%>
 NrpeBin=/usr/bin/nrpe
 NrpeCfg=<%= node['nrpe']['conf_dir'] %>/nrpe.cfg


### PR DESCRIPTION
Hey,

the nrpe service gets restarted every chef run for no reason. I checked the init script for the status command and there was the error, that the `status_of_proc` function does not exist.

I'm using ubuntu 12.04.

I think it's about the lsb-functions that need to be sourced when using them. 
