### PR TITLE
Project name changed from nagios-plugins to monitoring-plugins

### DIFF
--- a/recipes/_source_plugins.rb
+++ b/recipes/_source_plugins.rb
@@ -23,17 +23,17 @@
 
 plugins_version = node['nrpe']['plugins']['version']
 
-remote_file "#{Chef::Config[:file_cache_path]}/nagios-plugins-#{plugins_version}.tar.gz" do
-  source "#{node['nrpe']['plugins']['url']}/nagios-plugins-#{plugins_version}.tar.gz"
+remote_file "#{Chef::Config[:file_cache_path]}/monitoring-plugins-#{plugins_version}.tar.gz" do
+  source "#{node['nrpe']['plugins']['url']}/monitoring-plugins-#{plugins_version}.tar.gz"
   checksum node['nrpe']['plugins']['checksum']
   action :create_if_missing
 end
 
-bash 'compile-nagios-plugins' do
+bash 'compile-monitoring-plugins' do
   cwd Chef::Config[:file_cache_path]
   code <<-EOH
-    tar zxvf nagios-plugins-#{plugins_version}.tar.gz
-    cd nagios-plugins-#{plugins_version}
+    tar zxvf monitoring-plugins-#{plugins_version}.tar.gz
+    cd monitoring-plugins-#{plugins_version}
     ./configure --with-nagios-user=#{node['nrpe']['user']} \
                 --with-nagios-group=#{node['nrpe']['group']} \
                 --prefix=/usr \


### PR DESCRIPTION
Before the release of 2.0 the project name was changed to Monitoring Plugins. The source archive and included directory name were updated as well.

The current version of recipes/_source_plugins.rb fails with a HTTP 404 error.

This PR updates recipes/_source_plugins.rb to use the new names. 
