### PR TITLE
apt update before package installation on Debian based systems

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email  'tsmith84@gmail.com'
 license           'Apache 2.0'
 description       'Installs and configures Nagios NRPE client'
 long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '1.4.4'
+version           '1.5.0'
 
 recipe 'default', 'Installs and configures a nrpe client'
-%w(build-essential yum-epel).each do |cb|
+%w(apt build-essential yum-epel).each do |cb|
   depends cb
 end
 

--- a/recipes/_package_install.rb
+++ b/recipes/_package_install.rb
@@ -29,9 +29,16 @@ if platform_family?('rhel', 'fedora')
   end
 end
 
+# update apt repositories on debian platforms before installing
+case node['platform_family']
+when 'debian'
+  include_recipe 'apt'
+end
+
 # install the nrpe packages specified in the ['nrpe']['packages'] attribute
 node['nrpe']['packages'].each do |pkg|
   package pkg do
     options node['nrpe']['package']['options'] unless node['nrpe']['package']['options'].nil?
   end
 end
+


### PR DESCRIPTION
Installation of NRPE via the package was failing during bootstrap of generic Vagrant systems running Ubuntu 14.04.  This small change make sure that everything is up to date and apt-get knows where to download the package from.
