### PR TITLE
Put nrpe pidfile dirctly into the usual run directory - Fixes #7

### DIFF
--- a/templates/default/nagios-nrpe-server.erb
+++ b/templates/default/nagios-nrpe-server.erb
@@ -37,6 +37,7 @@ case "$1" in
 start)
   # Start daemon.
   echo -n "Starting <%= node['nrpe']['service_name'] %>: "
+  install -o <%= node['nrpe']['user'] %> -g <%= node['nrpe']['group'] %> -d `dirname $PidFile`
   <% if ['rhel', 'fedora'].include?(node['platform_family']) -%>daemon $NrpeBin -c $NrpeCfg -d<% else -%>start-stop-daemon --start --quiet --exec $NrpeBin -- -c $NrpeCfg -d<% end -%>
   echo
   ;;


### PR DESCRIPTION
Hey,

this PR tries to fix #7 . As described there , the nrpe daemon can't be reloaded properly, because the pid file was not created. It seems nrpe is not creating the pid file if the directory does not exist. Unfortunately the init script does not fail and so it's not properly reported to the chef run. With this PR the pid file is put directly into the usual run dir (which should always exist) and not in a separated pid directory. 
