### PR TITLE
Update metadata maintainer and repo urls

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,12 +1,12 @@
-name              'nrpe'
-maintainer        'Tim Smith'
-maintainer_email  'tsmith@chef.io'
-license           'Apache 2.0'
-description       'Installs and configures Nagios NRPE client'
-long_description  IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version           '2.0.0'
-issues_url       'https://github.com/schubergphilis/nrpe/issues'
-source_url       'https://github.com/schubergphilis/nrpe'
+name             'nrpe'
+maintainer       'Sous Chefs'
+maintainer_email 'help@sous-chefs.org'
+license          'Apache-2.0'
+description      'Installs and configures Nagios NRPE client'
+long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
+version          '2.0.0'
+issues_url       'https://github.com/sous-chefs/nrpe/issues'
+source_url       'https://github.com/sous-chefs/nrpe'
 chef_version     '>= 12.9' if respond_to?(:chef_version)
 
 recipe 'default', 'Installs and configures a nrpe client'


### PR DESCRIPTION
Update metadata info to reflect cookbook is now maintained by Sous Chefs.