### PR TITLE
Don't write an empty pid_file attribute

### DIFF
--- a/templates/default/nrpe.cfg.erb
+++ b/templates/default/nrpe.cfg.erb
@@ -3,7 +3,7 @@
 <%= "log_facility=#{node['nrpe']['log_facility']}" unless node['nrpe']['log_facility'].nil? %>
 <%= "allow_bash_command_substitution=#{node['nrpe']['allow_bash_command_substitution']}" unless node['nrpe']['allow_bash_command_substitution'].nil? %>
 <%= "command_prefix=#{node['nrpe']['command_prefix']}" unless node['nrpe']['command_prefix'].nil? %>
-pid_file=<%= node['nrpe']['pid_file'] %>
+<%= "pid_file=#{node['nrpe']['pid_file']} unless node['nrpe']['pid_file'].nil? %>
 server_port=<%= node['nrpe']['server_port'] %>
 <%= "server_address=#{node['nrpe']['server_address']}" unless node['nrpe']['server_address'].nil? %>
 nrpe_user=<%= node['nrpe']['user'] %>


### PR DESCRIPTION
Systemd doesn't require a pid-file so it might be useful to skip writing this attribute.
This change makes it the attribute fully configurable.

### Description

This change makes the pid_file attribute optional.

### Issues Resolved

It wasn't possible to run nrpe without a pid_file. 
NRPE fails when the pid_file option is configured but empty.

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
