### PR TITLE
allow IPv6 localhost ::1

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Configures the NRPE client. This will be called internally by the `default` reci
 ### authorization and server discovery
 
 - `node['nrpe']['server_role']` - the role that the Nagios server will have in its run list that the clients can search for.
-- `node['nrpe']['allowed_hosts']` - additional hosts that are allowed to connect to this client. Must be an array of strings (i.e. `%w(test.host other.host)`). These hosts are added in addition to 127.0.0.1 and IPs that are found via search.
+- `node['nrpe']['allowed_hosts']` - additional hosts that are allowed to connect to this client. Must be an array of strings (i.e. `%w(test.host other.host)`). These hosts are added in addition to 127.0.0.1, ::1, and IPs that are found via search.
 - `node['nrpe']['using_solo_search']` - discover server information in node data_bags even with chef solo through the use of solo-search (<https://github.com/edelight/chef-solo-search>)
 - `node['nrpe']['multi_environment_monitoring']` - search for nagios servers in all environments not just that of the node when building the array of allowed hosts, default 'false'
 

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -25,7 +25,7 @@
 #
 
 # determine hosts that NRPE will allow monitoring from. Start with localhost
-mon_host = ['127.0.0.1']
+mon_host = ['127.0.0.1', '::1']
 
 # search for nagios servers and add them to the mon_host array as well
 if node['nrpe']['multi_environment_monitoring']

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -39,7 +39,7 @@ describe 'default installation' do
   end
 
   it 'expects nrpe config to allow localhost polling' do
-    expect(chef_run).to render_file('/etc/nagios/nrpe.cfg').with_content('allowed_hosts=127.0.0.1')
+    expect(chef_run).to render_file('/etc/nagios/nrpe.cfg').with_content('allowed_hosts=127.0.0.1,::1')
   end
 
   it 'expects nrpe config to have dont_blame_nrpe' do


### PR DESCRIPTION
### Description

Allows the IPv6 localhost ::1 by default

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
