### PR TITLE
Add disable_search attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Configures the NRPE client. This will be called internally by the `default` reci
 - `node['nrpe']['server_role']` - the role that the Nagios server will have in its run list that the clients can search for.
 - `node['nrpe']['allowed_hosts']` - additional hosts that are allowed to connect to this client. Must be an array of strings (i.e. `%w(test.host other.host)`). These hosts are added in addition to 127.0.0.1, ::1, and IPs that are found via search.
 - `node['nrpe']['using_solo_search']` - discover server information in node data_bags even with chef solo through the use of solo-search (<https://github.com/edelight/chef-solo-search>)
+- `node['nrpe']['disable_search']` - Deactivate usage of search against the chef server
 - `node['nrpe']['multi_environment_monitoring']` - search for nagios servers in all environments not just that of the node when building the array of allowed hosts, default 'false'
 
 ### user and group attributes

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -57,6 +57,7 @@ default['nrpe']['checksum'] = '66383b7d367de25ba031d37762d83e2b55de010c573009c6f
 default['nrpe']['server_role'] = 'monitoring'
 default['nrpe']['allowed_hosts'] = nil
 default['nrpe']['using_solo_search'] = false
+default['nrpe']['disable_search'] = false
 default['nrpe']['multi_environment_monitoring'] = false
 # this is mostly true except for centos-70
 default['nrpe']['check_action'] = 'reload'

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -32,7 +32,7 @@ if node['nrpe']['multi_environment_monitoring']
   search(:node, "roles:#{node['nrpe']['server_role']}") do |n|
     mon_host << n['ipaddress']
   end
-elsif (!Chef::Config[:solo] && !node['nrpe']['disable_search'])|| node['nrpe']['using_solo_search']
+elsif (!Chef::Config[:solo] && !node['nrpe']['disable_search']) || node['nrpe']['using_solo_search']
   search(:node, "roles:#{node['nrpe']['server_role']} AND chef_environment:#{node.chef_environment}") do |n|
     mon_host << n['ipaddress']
   end

--- a/recipes/configure.rb
+++ b/recipes/configure.rb
@@ -32,7 +32,7 @@ if node['nrpe']['multi_environment_monitoring']
   search(:node, "roles:#{node['nrpe']['server_role']}") do |n|
     mon_host << n['ipaddress']
   end
-elsif !Chef::Config[:solo] || node['nrpe']['using_solo_search']
+elsif (!Chef::Config[:solo] && !node['nrpe']['disable_search'])|| node['nrpe']['using_solo_search']
   search(:node, "roles:#{node['nrpe']['server_role']} AND chef_environment:#{node.chef_environment}") do |n|
     mon_host << n['ipaddress']
   end


### PR DESCRIPTION
This will avoid querying chef servers on infrastructure where it is not
relevant (for those using allowed_hosts directly for instance)

Change-Id: Idf42aeaa85b2e7cb2894b118aedc49ee36813ec5