### PR TITLE
Systemd systems fail to start nrpe on boot. Updated nrpe to get it working via cookbook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This file is used to list changes made in each version of nrpe
 - Remove windows references and use Chef defaults for `file` and `template` resources
 - Update checks for `node['platform_family']` to handle `amazon`
 - Respect NRPE version attribute
+- Update NRPE version
+- Systemd tmpfiles config updated to create the nrpe directory in the run directories for the configured pid directory
 
 ## 2.0.5 (2018-12-14)
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -50,8 +50,8 @@ default['nrpe']['plugins']['checksum'] = '76c6b58f0867ab7b6c8c86c7e94fcce7183618
 
 # for nrpe from source installation
 default['nrpe']['url']      = 'http://prdownloads.sourceforge.net/sourceforge/nagios'
-default['nrpe']['version']  = '2.15'
-default['nrpe']['checksum'] = '66383b7d367de25ba031d37762d83e2b55de010c573009c6f58270b137131072'
+default['nrpe']['version']  = '3.2.1'
+default['nrpe']['checksum'] = '8ad2d1846ab9011fdd2942b8fc0c99dfad9a97e57f4a3e6e394a4ead99c0f1f0'
 
 # authorization options
 default['nrpe']['server_role'] = 'monitoring'
@@ -71,7 +71,8 @@ default['nrpe']['systemd_unit_dir'] = '/usr/lib/systemd/system'
 case node['platform_family']
 when 'debian'
   default['nrpe']['install_method']    = 'package'
-  default['nrpe']['pid_file']          = '/var/run/nagios/nrpe.pid'
+  default['nrpe']['pid_dir']           = '/var/run/nagios/'
+  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
   default['nrpe']['home']              = '/usr/lib/nagios'
   default['nrpe']['packages']          = {
     'nagios-nrpe-server' => {
@@ -110,7 +111,8 @@ when 'rhel', 'fedora', 'amazon'
   default['nrpe']['group'] = 'nrpe'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['install_yum-epel']  = true
-  default['nrpe']['pid_file']          = '/var/run/nrpe/nrpe.pid'
+  default['nrpe']['pid_dir']           = '/var/run/nagios/'
+  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
   default['nrpe']['packages']          = {
     'nrpe' => {
       'version' => nil,
@@ -142,7 +144,8 @@ when 'rhel', 'fedora', 'amazon'
   default['nrpe']['bin_dir']           = '/usr/sbin'
 when 'freebsd'
   default['nrpe']['install_method']    = 'package'
-  default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
+  default['nrpe']['pid_dir']           = '/var/run/nrpe2/'
+  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe2.pid'
   default['nrpe']['packages']          = {
     'nrpe' => {
       'version' => nil,
@@ -157,7 +160,8 @@ else
   # suse enterprise doesn't have a package, but modern opensuse does
   if node['platform'] == 'opensuseleap'
     default['nrpe']['install_method']    = 'package'
-    default['nrpe']['pid_file']          = '/run/nrpe/nrpe.pid'
+    default['nrpe']['pid_dir']           = '/run/nrpe/'
+    default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
     default['nrpe']['home']              = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']       = '/usr/lib'
     default['nrpe']['service_name']      = 'nrpe'
@@ -174,7 +178,8 @@ else
     }
   else
     default['nrpe']['install_method']    = 'source'
-    default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
+    default['nrpe']['pid_dir']           = '/var/run/'
+    default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
     default['nrpe']['home']              = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']       = '/usr/lib'
     default['nrpe']['service_name']      = 'nrpe'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -71,8 +71,7 @@ default['nrpe']['systemd_unit_dir'] = '/usr/lib/systemd/system'
 case node['platform_family']
 when 'debian'
   default['nrpe']['install_method']    = 'package'
-  default['nrpe']['pid_dir']           = '/var/run/nagios/'
-  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
+  default['nrpe']['pid_file']          = '/var/run/nagios/nrpe.pid'
   default['nrpe']['home']              = '/usr/lib/nagios'
   default['nrpe']['packages']          = {
     'nagios-nrpe-server' => {
@@ -111,8 +110,7 @@ when 'rhel', 'fedora', 'amazon'
   default['nrpe']['group'] = 'nrpe'
   default['nrpe']['install_method']    = 'package'
   default['nrpe']['install_yum-epel']  = true
-  default['nrpe']['pid_dir']           = '/var/run/nagios/'
-  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
+  default['nrpe']['pid_file']          = '/var/run/nrpe/nrpe.pid'
   default['nrpe']['packages']          = {
     'nrpe' => {
       'version' => nil,
@@ -144,8 +142,7 @@ when 'rhel', 'fedora', 'amazon'
   default['nrpe']['bin_dir']           = '/usr/sbin'
 when 'freebsd'
   default['nrpe']['install_method']    = 'package'
-  default['nrpe']['pid_dir']           = '/var/run/nrpe2/'
-  default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe2.pid'
+  default['nrpe']['pid_file']          = '/var/run/nrpe2/nrpe2.pid'
   default['nrpe']['packages']          = {
     'nrpe' => {
       'version' => nil,
@@ -160,8 +157,7 @@ else
   # suse enterprise doesn't have a package, but modern opensuse does
   if node['platform'] == 'opensuseleap'
     default['nrpe']['install_method']    = 'package'
-    default['nrpe']['pid_dir']           = '/run/nrpe/'
-    default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
+    default['nrpe']['pid_file']          = '/run/nrpe/nrpe.pid'
     default['nrpe']['home']              = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']       = '/usr/lib'
     default['nrpe']['service_name']      = 'nrpe'
@@ -178,8 +174,7 @@ else
     }
   else
     default['nrpe']['install_method']    = 'source'
-    default['nrpe']['pid_dir']           = '/var/run/'
-    default['nrpe']['pid_file']          = node['nrpe']['pid_dir'] + 'nrpe.pid'
+    default['nrpe']['pid_file']          = '/var/run/nrpe.pid'
     default['nrpe']['home']              = '/usr/lib/nagios'
     default['nrpe']['ssl_lib_dir']       = '/usr/lib'
     default['nrpe']['service_name']      = 'nrpe'

--- a/recipes/_source_nrpe.rb
+++ b/recipes/_source_nrpe.rb
@@ -78,15 +78,18 @@ bash 'compile-nagios-nrpe' do
   not_if "nrpe --version | grep #{node['nrpe']['version']}"
 end
 
-directory node['nrpe']['pid_dir'] do
+directory ::File.dirname(node['nrpe']['pid_file']) do
   user node['nrpe']['user']
   group node['nrpe']['group']
   mode '0755'
-  only_if { node['init_system'] == 'systemd' }
+  only_if  { node['init_package'] == 'systemd' }
 end
 
 template '/usr/lib/tmpfiles.d/nrpe.conf' do
   source 'nrpe-tmpfiles.d.erb'
   mode '0644'
-  only_if { node['init_system'] == 'systemd' }
+  variables(
+    pid_dir: ::File.dirname(node['nrpe']['pid_file'])
+  )
+  only_if  { node['init_package'] == 'systemd' }
 end

--- a/recipes/_source_nrpe.rb
+++ b/recipes/_source_nrpe.rb
@@ -77,3 +77,16 @@ bash 'compile-nagios-nrpe' do
   EOH
   not_if "nrpe --version | grep #{node['nrpe']['version']}"
 end
+
+directory node['nrpe']['pid_dir'] do
+  user node['nrpe']['user']
+  group node['nrpe']['group']
+  mode '0755'
+  only_if { node['init_system'] == 'systemd' }
+end
+
+template '/usr/lib/tmpfiles.d/nrpe.conf' do
+  source 'nrpe-tmpfiles.d.erb'
+  mode '0644'
+  only_if { node['init_system'] == 'systemd' }
+end

--- a/templates/default/nrpe-tmpfiles.d.erb
+++ b/templates/default/nrpe-tmpfiles.d.erb
@@ -1,0 +1,2 @@
+#Type	Path			Mode	UID				GID			Age	Argument
+d		<%= node['nrpe']['pid_dir'] %>	0755	<%= node['nrpe']['user'] %>	<%= node['nrpe']['group'] %>	-	-

--- a/templates/default/nrpe-tmpfiles.d.erb
+++ b/templates/default/nrpe-tmpfiles.d.erb
@@ -1,2 +1,2 @@
 #Type	Path			Mode	UID				GID			Age	Argument
-d		<%= node['nrpe']['pid_dir'] %>	0755	<%= node['nrpe']['user'] %>	<%= node['nrpe']['group'] %>	-	-
+d		<%= @pid_dir %>	0755	<%= node['nrpe']['user'] %>	<%= node['nrpe']['group'] %>	-	-


### PR DESCRIPTION
# Description

Updated nrpe to work with cookbook changes before pid changes. 
Updated systemd tmpfile config file to be managed by chef so pid failures wont happen on boot.

## Issues Resolved

N/A (I can make an issue if one is needed)

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
