### PR TITLE
Add bin dir path to version check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file is used to list changes made in each version of nrpe
 
 ## Unreleased
 
- - Add bin_dir to nrpe version check
+- Add bin_dir to nrpe version check
 
 ## 3.0.0 (2020-01-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of nrpe
 
+## Unreleased
+
+ - Add bin_dir to nrpe version check
+
 ## 3.0.0 (2020-01-26)
 
 - Require Chef Infra Client 14 or later

--- a/recipes/_source_nrpe.rb
+++ b/recipes/_source_nrpe.rb
@@ -75,7 +75,7 @@ bash 'compile-nagios-nrpe' do
     make all
     make install
   EOH
-  not_if "nrpe --version | grep #{node['nrpe']['version']}"
+  not_if "#{node['nrpe']['bin_dir']}/nrpe --version | grep #{node['nrpe']['version']}"
 end
 
 directory ::File.dirname(node['nrpe']['pid_file']) do

--- a/spec/ubuntu_source_spec.rb
+++ b/spec/ubuntu_source_spec.rb
@@ -9,7 +9,7 @@ describe 'source install on ubuntu' do
 
   before do
     stub_command('which nrpe').and_return(false)
-    stub_command('nrpe --version | grep 3.2.1').and_return(false)
+    stub_command('/usr/sbin/nrpe --version | grep 3.2.1').and_return(false)
   end
 
   it 'templates systemd unit file' do


### PR DESCRIPTION
# Description

We discovered a few nodes in our stack that were centos 6 had the nrpe installed in /usr/bin/nrpe and was the one getting picked up. The cookbook would compile the newer version and put it in /usr/sbin/nrpe. That new one was ignored and would cause the cookbook every run to compile nrpe.

## Issues Resolved

Should I create an issue?

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
