### PR TITLE
Enable unified_mode for Chef 17 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,16 +40,17 @@ jobs:
     strategy:
       matrix:
         os:
-          - 'centos-7'
-          - 'debian-9'
-          - 'debian-10'
-          - 'ubuntu-1604'
-          - 'ubuntu-1804'
-          - 'opensuse-leap-15'
+          - centos-7
+          - centos-8
+          - debian-9
+          - debian-10
+          - ubuntu-1804
+          - ubuntu-2004
+          - opensuse-leap-15
         suite:
-          - 'package'
-          - 'source'
-          - 'check'
+          - package
+          - source
+          - check
       fail-fast: false
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This file is used to list changes made in each version of nrpe
 
+## Unreleased
+
+- Enable `unified_mode` for Chef 17 compatibility
+- Bump minimum Chef version to 15.3
+
 ## 3.0.1 (2020-05-05)
 
 - Add bin_dir to nrpe version check
@@ -9,7 +14,7 @@ This file is used to list changes made in each version of nrpe
 ## 3.0.0 (2020-01-26)
 
 - Require Chef Infra Client 14 or later
-- Fix failing openSUSE source installs by adding gzip as a depedency package
+- Fix failing openSUSE source installs by adding gzip as a dependency package
 - Better check for systemd platforms
 - Don't rely on the build-essential cookbook now that build_essential resource is built-in
 - Resolve all the latest cookstyle warnings

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This cookbook is maintained by the Sous Chefs. The Sous Chefs are a community of
 
 ### Chef
 
-Chef 14+
+Chef 15.3+
 
 ### Platform
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -26,13 +26,6 @@ platforms:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-8
-    driver:
-      image: dokken/debian-8
-      pid_one_command: /bin/systemd
-      intermediate_instructions:
-        - RUN /usr/bin/apt-get update
-
   - name: debian-9
     driver:
       image: dokken/debian-9
@@ -47,11 +40,6 @@ platforms:
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: centos-6
-    driver:
-      image: dokken/centos-6
-      pid_one_command: /sbin/init
-
   - name: centos-7
     driver:
       image: dokken/centos-7
@@ -61,11 +49,6 @@ platforms:
     driver:
       image: dokken/centos-8
       pid_one_command: /usr/lib/systemd/systemd
-
-  - name: oraclelinux-6
-    driver:
-      image: dokken/oraclelinux-6
-      pid_one_command: /sbin/init
 
   - name: oraclelinux-7
     driver:
@@ -82,16 +65,16 @@ platforms:
       image: dokken/fedora-latest
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: ubuntu-16.04
+  - name: ubuntu-18.04
     driver:
-      image: dokken/ubuntu-16.04
+      image: dokken/ubuntu-18.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
 
-  - name: ubuntu-18.04
+  - name: ubuntu-20.04
     driver:
-      image: dokken/ubuntu-18.04
+      image: dokken/ubuntu-20.04
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -12,18 +12,15 @@ platforms:
     driver_config:
       box: mvbcoding/awslinux
   - name: amazonlinux-2
-  - name: centos-6
   - name: centos-7
   - name: centos-8
-  - name: debian-8
   - name: debian-9
   - name: debian-10
-  - name: fedora-29
+  - name: fedora-latest
   - name: freebsd-12
   - name: opensuse-leap-15
-  - name: ubuntu-16.04
   - name: ubuntu-18.04
-  - name: ubuntu-19.04
+  - name: ubuntu-20.04
 
 suites:
   - name: package

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description      'Installs and configures Nagios NRPE client'
 version          '3.0.2'
 issues_url       'https://github.com/sous-chefs/nrpe/issues'
 source_url       'https://github.com/sous-chefs/nrpe'
-chef_version     '>= 14'
+chef_version     '>= 15.3'
 
 depends 'yum-epel'
 

--- a/resources/check.rb
+++ b/resources/check.rb
@@ -19,6 +19,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+unified_mode true
+
 # Name of the nrpe check, used for the filename and the command name
 property :command_name, String, name_property: true
 property :warning_condition, [Integer, String]

--- a/test/integration/check/inspec/check_spec.rb
+++ b/test/integration/check/inspec/check_spec.rb
@@ -1,0 +1,6 @@
+nrpe_dir = os.suse? ? '/etc/nrpe.d' : '/etc/nagios/nrpe.d'
+
+describe file("#{nrpe_dir}/check_root_disk_space.cfg") do
+  it { should exist }
+  its('content') { should match %r{command\[check_root_disk_space\]=/usr/lib(64)?/nagios/plugins/check_disk -w 5% -c 1% -p} }
+end

--- a/test/integration/package/inspec/package_spec.rb
+++ b/test/integration/package/inspec/package_spec.rb
@@ -1,0 +1,10 @@
+nrpe = os.debian? ? 'nagios-nrpe-server' : 'nrpe'
+
+describe package(nrpe) do
+  it { should be_installed }
+end
+
+describe service(nrpe) do
+  it { should be_enabled }
+  it { should be_running }
+end

--- a/test/integration/source/inspec/source_spec.rb
+++ b/test/integration/source/inspec/source_spec.rb
@@ -1,0 +1,19 @@
+nrpe_user = os.redhat? ?  'nrpe' : 'nagios'
+
+describe group(nrpe_user) do
+  it { should exist }
+end
+
+describe user(nrpe_user) do
+  it { should exist }
+end
+
+describe file('/usr/sbin/nrpe') do
+  it { should exist }
+  it { should be_executable }
+end
+
+describe service('nrpe') do
+  it { should be_enabled }
+  it { should be_running }
+end


### PR DESCRIPTION
Signed-off-by: Robert Detjens <detjensrobert@osuosl.org>

# Description

Enable `unified_mode` for Chef 17 compatibility.

Major bump as this bumps the required Chef version to 15.3.

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.
