### PR TITLE
Update tested platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,15 @@ jobs:
     strategy:
       matrix:
         os:
+          - almalinux-8
           - centos-7
-          - centos-8
-          - debian-9
+          - centos-stream-8
           - debian-10
+          - debian-11
           - ubuntu-1804
           - ubuntu-2004
           - opensuse-leap-15
+          - rockylinux-8
         suite:
           - package
           - source

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of nrpe
 
 ## Unreleased
 
+- Update tested platforms
+
 ## 4.0.2 - *2022-01-25*
 
 - Cookstyle fixes

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -15,24 +15,24 @@ verifier:
   name: inspec
 
 platforms:
-  - name: amazonlinux
+  - name: almalinux-8
     driver:
-      image: dokken/amazonlinux
-      pid_one_command: /sbin/init
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
 
   - name: amazonlinux-2
     driver:
       image: dokken/amazonlinux-2
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: debian-9
-    driver:
-      image: dokken/debian-9
-      pid_one_command: /bin/systemd
-
   - name: debian-10
     driver:
       image: dokken/debian-10
+      pid_one_command: /bin/systemd
+
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
       pid_one_command: /bin/systemd
 
   - name: centos-7
@@ -40,9 +40,9 @@ platforms:
       image: dokken/centos-7
       pid_one_command: /usr/lib/systemd/systemd
 
-  - name: centos-8
+  - name: centos-stream-8
     driver:
-      image: dokken/centos-8
+      image: dokken/centos-stream-8
       pid_one_command: /usr/lib/systemd/systemd
 
   - name: oraclelinux-7
@@ -73,4 +73,9 @@ platforms:
   - name: opensuse-leap-15
     driver:
       image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
+
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
       pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -10,17 +10,16 @@ provisioner:
   chef_license: accept-no-persist
 
 platforms:
-  - name: amazonlinux
-    driver_config:
-      box: mvbcoding/awslinux
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
   - name: fedora-latest
   - name: freebsd-12
   - name: opensuse-leap-15
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 


### PR DESCRIPTION
- Remove CentOS 8 Linux, Amazon Linux & Debian 9
- Add Alma Linux 8, Rocky Linux 8, Debian 11 and CentOS Stream 8

Signed-off-by: Lance Albertson <lance@osuosl.org>
