### PR TITLE
chore: migrate nrpe to Policyfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: ci
 
 jobs:
   lint-unit:
-    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@8.0.2
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@9.0.0
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -20,5 +20,5 @@ jobs:
         uses: actions/checkout@v7
       - name: Install Chef
         uses: actionshub/chef-install@main
-      - name: Install cookbooks
-        run: berks install
+      - name: Install Policyfile dependencies
+        run: chef install Policyfile.rb

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ doc/
 rdoc
 
 # chef infra stuff
-Berksfile.lock
 .kitchen
 kitchen.local.yml
 vendor/

--- a/Berksfile
+++ b/Berksfile
@@ -1,9 +1,0 @@
-# frozen_string_literal: true
-
-source 'https://supermarket.chef.io'
-
-metadata
-
-group :integration do
-  cookbook 'test', path: 'test/cookbooks/test'
-end

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+name 'nrpe'
+
+run_list 'test::default'
+
+cookbook 'nrpe', path: '.'
+cookbook 'test', path: './test/cookbooks/test'
+
+Dir.glob('./test/cookbooks/test/recipes/*.rb').sort.each do |recipe|
+  name = File.basename(recipe, '.rb')
+  named_run_list :"#{name}", "test::#{name}"
+end

--- a/chefignore
+++ b/chefignore
@@ -83,13 +83,6 @@ test/*
 */.hg/*
 */.svn/*
 
-# Berkshelf #
-#############
-Berksfile
-Berksfile.lock
-cookbooks/*
-tmp
-
 # Bundler #
 ###########
 vendor/*

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,11 +3,14 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   multiple_converge: 2
   enforce_idempotency: true
   deprecations_as_errors: true
   chef_license: accept-no-persist
+
+verifier:
+  name: inspec
 
 platforms:
   - name: almalinux-8

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -48,10 +48,16 @@ x-verifiers:
 suites:
   - name: default
     run_list: *default_run_list
+    provisioner:
+      named_run_list: default
     verifier: *default_verifier
   - name: source
     run_list: *source_run_list
+    provisioner:
+      named_run_list: source
     verifier: *source_verifier
   - name: check
     run_list: *check_run_list
+    provisioner:
+      named_run_list: check
     verifier: *check_verifier

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'chefspec'
-require 'chefspec/berkshelf'
+require 'chefspec/policyfile'
 
 RSpec.configure do |config|
   config.color = true

--- a/test/cookbooks/test/recipes/check.rb
+++ b/test/cookbooks/test/recipes/check.rb
@@ -2,11 +2,17 @@
 
 apt_update 'update' if platform_family?('debian')
 
-nrpe 'default'
+nrpe 'default' do
+  action %i(install configure)
+end
 
 nrpe_check 'check_root_disk_space' do
   command '/usr/lib/nagios/plugins/check_disk'
   warning_condition '5%'
   critical_condition '1%'
   parameters '-p /'
+end
+
+nrpe 'default' do
+  action :start
 end


### PR DESCRIPTION
## Summary

- replace Berksfile dependency resolution with Policyfile.rb
- switch ChefSpec to `chefspec/policyfile`
- update Kitchen's primary provisioner to `policyfile_zero`
- update Copilot setup and lint-unit workflow for Policyfile-based CI

## Validation

- `chef install Policyfile.rb`
- `chef update Policyfile.rb`
- `cookstyle`
- `chef exec rspec --format documentation` failed before examples due local user gem native extension code-signing; reran with Workstation embedded gems:
  `env GEM_HOME=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 GEM_PATH=/opt/chef-workstation/embedded/lib/ruby/gems/3.1.0 /opt/chef-workstation/embedded/bin/rspec --format documentation`
- `markdownlint-cli2 "**/*.md"`
- `yamllint .`
- `actionlint`
- `git diff HEAD --check`
- `env -u KITCHEN_LOCAL_YAML kitchen list`
- `env -u KITCHEN_LOCAL_YAML kitchen diagnose default-ubuntu-2404`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list`
- `KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen diagnose default-ubuntu-2404` failed because local Docker was not running
- `env -u KITCHEN_LOCAL_YAML kitchen test default-ubuntu-2404 --destroy=always`
- explicit idempotence sequence: `kitchen create`, `kitchen converge`, `kitchen converge`, `kitchen verify`, `kitchen destroy` for `default-ubuntu-2404`

Kitchen evidence: second converge completed with `Infra Phase complete, 0/14 resources updated`; InSpec reported 3 successful controls and 5 successful tests.
